### PR TITLE
Build cuda for native and make Vulkan actually optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Either Vulkan, CUDA, or Metal can be used as the inference backend.
 
 ```bash
 # A normal release build
-cargo build --locked --profile=optimized-release --package=sauropod-inference-server
+cargo build --locked --profile=optimized-release --features=vulkan --package=sauropod-inference-server
 
 # For systems with Nvidia GPUs
 cargo build --locked --profile=optimized-release --features=cuda --package=sauropod-inference-server

--- a/bindings/llama-cpp-sys/build.rs
+++ b/bindings/llama-cpp-sys/build.rs
@@ -119,7 +119,7 @@ fn build_llama(source_dir: &Path) -> PathBuf {
         .define("LLAMA_STATIC", "ON")
         .define("GGML_NATIVE", "OFF")
         .define("GGML_LTO", linker_plugin_lto)
-        .define("CMAKE_CUDA_ARCHITECTURES", "86;89;120");
+        .define("CMAKE_CUDA_ARCHITECTURES", "native");
 
     if let Some(target_cpu) = target_cpu_regex
         .captures_iter(&rust_flags)

--- a/crates/inference-server/Cargo.toml
+++ b/crates/inference-server/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-default = ["vulkan"]
+default = []
 cuda = ["sauropod-inference-engine/cuda"]
 vulkan = ["sauropod-inference-engine/vulkan"]
 profiling = ["sauropod-profiling/profiling"]


### PR DESCRIPTION
Unless there's a cross compile mechanism implemented/planned it's only going to build for the native machine. Using `native` builds faster, and doesn't lock the CUDA version to be >=12.8 for compute_120 (I found this out because I have 12.6 installed to match the Jetpack version we are forced to use right now for other dependency reasons and couldn't build the repo with it).

Also not a rust expert but from my understanding and from what I was seeing (couldn't build for missing vulkan libs even though I was using `--features=cuda`) features are additive, so having `default = ["vulkan"]` made it a required dependency not an optional one. (i.e. building with `--features=cuda` built both the vulkan and cuda backends, it didn't replace the vulkan one). So that either needs to be removed from the default like in this PR or those packages need to be moved out of the optional section and into required.