### PR TITLE
Add native cuda arch detection support for older cmake versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,38 +197,68 @@ jobs:
         uses: ./.github/actions/set-up-docker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download container digests
+      - name: Download Vulkan container digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          path: ${{ runner.temp }}/digests-vulkan
+          pattern: digests-vulkan-*
           merge-multiple: true
-      - name: Docker metadata
-        id: docker-metadata
+      - name: Download CUDA container digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: ${{ runner.temp }}/digests-cuda
+          pattern: digests-cuda-*
+          merge-multiple: true
+      - name: Docker Vulkan metadata
+        id: docker-metadata-vulkan
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           flavor: |
             latest=false
+            suffix=-vulkan
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-      - name: Create container manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+      - name: Docker CUDA metadata
+        id: docker-metadata-cuda
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        with:
+          flavor: |
+            latest=false
+            suffix=-cuda
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Create Vulkan container manifest list and push
+        working-directory: ${{ runner.temp }}/digests-vulkan
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-      - name: Get final merged image digest
+      - name: Create CUDA container manifest list and push
+        working-directory: ${{ runner.temp }}/digests-cuda
         run: |
-          echo "IMAGE_DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.docker-metadata.outputs.version  }} --format '{{ json .Manifest.Digest }}' | jq -r)" >> $GITHUB_ENV
-      - name: Attestation for Docker image
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Get final merged image digests
+        run: |
+          echo "IMAGE_DIGEST_VULKAN=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.docker-metadata-vulkan.outputs.version  }} --format '{{ json .Manifest.Digest }}' | jq -r)" >> $GITHUB_ENV
+          echo "IMAGE_DIGEST_CUDA=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.docker-metadata-cuda.outputs.version  }} --format '{{ json .Manifest.Digest }}' | jq -r)" >> $GITHUB_ENV
+      - name: Attestation for Vulkan Docker image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        id: attest
+        id: attest-vulkan
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ env.IMAGE_DIGEST }}
+          subject-digest: ${{ env.IMAGE_DIGEST_VULKAN }}
           push-to-registry: true
         if: github.repository == 'sauropod-io/sauropod'
-
+      - name: Attestation for CUDA Docker image
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        id: attest-cuda
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ env.IMAGE_DIGEST_CUDA }}
+          push-to-registry: true
+        if: github.repository == 'sauropod-io/sauropod'
       - name: Download X86 artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/bindings/llama-cpp-sys/build.rs
+++ b/bindings/llama-cpp-sys/build.rs
@@ -38,13 +38,23 @@ fn detect_gpu_arch() -> String {
         );
     }
 
-    let cap_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let parts: Vec<&str> = cap_str.split('.').collect();
-    if parts.len() != 2 {
-        panic!("Unexpected compute_cap format from nvidia-smi: '{cap_str}'");
-    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut archs = stdout
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim();
+            let parts: Vec<&str> = trimmed.split('.').collect();
+            if parts.len() != 2 {
+                panic!("Unexpected compute_cap format from nvidia-smi: '{trimmed}'");
+            }
+            format!("{}{}", parts[0], parts[1])
+        })
+        .collect::<std::collections::HashSet<_>>(); // deduplicate
 
-    format!("{}{}", parts[0], parts[1])
+    let mut archs_vec = archs.drain().collect::<Vec<_>>();
+    archs_vec.sort(); // optional: for consistent output order
+
+    archs_vec.join(";")
 }
 
 fn main() {


### PR DESCRIPTION
Apparently `native` for CUDA_ARCHITECTURES was only added to [cmake in 3.24](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html). To use this with the orin nano, which is running Jetpack 6.2 (which is the latest, and with up to date apt packages) ships with cmake 3.22.1. And it ships with CUDA 12.6 which doesn't support compute_120 so detecting the architecture is needed.

This PR just adds support to detect it with `nvidia-smi` which should just work for all cmake and CUDA versions. With this PR the repo now builds on the orin nano. It should be a functional no-op to what was there before, just works independent of cmake versions now.